### PR TITLE
nit readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LLMOps with Prompt Flow (preview)
-Large Language Operations, or LLMOps, has become the cornerstone of efficient prompt engineering and LLM induced application development and deployment. As the demand for LLM induced applications continues to soar, organizations find themselves in need of a cohesive and streamlined process to manage their end-to-end lifecycle.
+Large Language Model Operations, or LLMOps, has become the cornerstone of efficient prompt engineering and LLM induced application development and deployment. As the demand for LLM induced applications continues to soar, organizations find themselves in need of a cohesive and streamlined process to manage their end-to-end lifecycle.
 
 The rise of AI and large language models (LLMs) has transformed various industries, enabling the development of innovative applications with human-like text understanding and generation capabilities. This revolution has opened up new possibilities across fields such as customer service, content creation, and data analysis.
 
@@ -16,9 +16,9 @@ As LLMs rapidly evolve, the importance of Prompt Engineering becomes increasingl
 - It involves handling multiple flows, their unique lifecycles, experimentation with various configurations, and ensuring smooth deployments.
 
 # Context
-- LLM-infused application are designed to understand and generate human-like text based on the input they receive. They comprise of prompts that needs engineering cadence and rigour.
-- Prompt flow is a powerful feature that simplifies and streamlines the Prompt Engineering process for LLM-infused applications. It enables users to create, evaluate, and deploy high-quality flows with ease and efficiency. 
-- How do we best augment LLM-infused application with LLMOps and engineering rigour? This template aims to assist in the development of those types of applications using Prompt Flow and LLMOps.
+- LLM-infused applications are designed to understand and generate human-like text based on the input they receive. They comprise of prompts that needs engineering cadence and rigour.
+- Prompt flow is a powerful feature that simplifies and streamlines the Prompt Engineering process for LLM-infused applications. It enables users to create, evaluate, and deploy high-quality flows with ease and efficiency.
+- How do we best augment LLM-infused applications with LLMOps and engineering rigour? This template aims to assist in the development of those types of applications using Prompt Flow and LLMOps.
 
 # Solution
 
@@ -53,18 +53,18 @@ Each use case (set of Prompt Flow standard and evaluation flows) should follow t
 
 - .azure-pipelines : It contains the CI and PR related pipeline for Azure DevOps and specific to a use-case
 - configs          : It contains data, deployment and prompt flow data mapping related configuration files.
-- data             : This folder contains data files related to Prompt Flow standard and eevaluation flow
-- environment      : It contains Conda file for python package dependencies needed for deployment environment. 
-- flows            : It should contain minimally two folder - one for standard Prompt Flow related files and other for Evaluation flow related file. There can be multiple evaluation flow related folders.
+- data             : This folder contains data files related to Prompt Flow standard and evaluation flow
+- environment      : It contains Conda file for python package dependencies needed for deployment environment.
+- flows            : It should contain minimally two folders - one for standard Prompt Flow related files and other for Evaluation flow related files. There can be multiple evaluation flow related folders.
 - tests            : contains unit tests for the flows
 
-Additionally, there is a config.json file that refers important infrastructure and flow related information. There is also a sample-request.json file containing test ata for testing endpoints after deployment. 
+Additionally, there is a config.json file that refers important infrastructure and flow related information. There is also a sample-request.json file containing test data for testing endpoints after deployment.
 
-- The '.azure-pipelines' folder contains the common Azure DevOps pipelines for the platform and any changes to them will impact exeuction of all the flows.
+- The '.azure-pipelines' folder contains the common Azure DevOps Pipelines for the platform and any changes to them will impact exeuction of all the flows.
 
-- The '.github' folder contains the Github workflows for the platform as well as the use-cases. This is bit different than Azure DevOps because all Github Workflows should be within this single folder for execution.
+- The '.github' folder contains the Github workflows for the platform as well as the use-cases. This is bit different than Azure DevOps because all Github workflows should be within this single folder for execution.
 
-- The 'docs' folder contains documentation for step by step guide for both Azure DevOps and Github Workflow related configuration.
+- The 'docs' folder contains documentation for step-by-step guide for both Azure DevOps and Github workflow related configuration.
 
 - The 'llmops' folder contains all the code related to flow execution, evaluation and deployment.
 
@@ -73,8 +73,8 @@ Additionally, there is a config.json file that refers important infrastructure a
 # Documentation
 
 - Full documentation on using this repo using Azure DevOps can be found [here](./docs/Azure_devops_how_to_setup.md)
-- Full documentation on using this repo using Github Workflows can be found [here](./docs/github_workflows_how_to_setup.md)
-- documentation can adding a new flow is available [here](./docs/how_to_onboard_new_flows.md)
+- Full documentation on using this repo using Github workflows can be found [here](./docs/github_workflows_how_to_setup.md)
+- Documentation on adding a new flow is available [here](./docs/how_to_onboard_new_flows.md)
 
 # Deployment
 

--- a/docs/github_workflows_how_to_setup.md
+++ b/docs/github_workflows_how_to_setup.md
@@ -26,7 +26,7 @@ Prompt Flow runtimes are optional by default for this template. The template use
 
 ## Create service principal
 
-Create one Azure service principal for the purpose of understanding this repository. You can add more depending on how many environments, you want to work on (Dev or Prod or Both). Service principals can be created using cloud shell, bash, powershell or from Azure UI.  If your subscription is part of an organization with multiple tenants, ensure that the Service Principal has access across tenants. 
+Create one Azure service principal for the purpose of understanding this repository. You can add more depending on how many environments you want to work on (Dev or Prod or Both). Service principals can be created using cloud shell, bash, powershell or from Azure UI.  If your subscription is part of an organization with multiple tenants, ensure that the Service Principal has access across tenants. 
 
 1. Copy the following bash commands to your computer and update the **spname** and  **subscriptionId** variables with the values for your project. This command will also grant the **Contributor** role to the service principal in the subscription provided. This is required for GitHub Actions to properly use resources in that subscription. 
 
@@ -37,7 +37,7 @@ Create one Azure service principal for the purpose of understanding this reposit
     servicePrincipalName="Azure-ARM-${spname}"
     
     # Verify the ID of the active subscription
-    echo "Using subscription ID $subscriptionID"
+    echo "Using subscription ID $subscriptionId"
     echo "Creating SP for RBAC with name $servicePrincipalName, with role $roleName and in scopes     /subscriptions/$subscriptionId"
     
     az ad sp create-for-rbac --name $servicePrincipalName --role $roleName --scopes /subscriptions/$subscriptionId --sdk-auth 
@@ -94,7 +94,7 @@ Eventually, the default branch in github repo should show `development` as the d
 
 ![make development branch as default branch](images/default-branch.png)
 
-The template comes with few Github workflow related to Prompt Flow flows for providing a jumpstart (named_entity_recognition, web_classification and math_coding). Each scenerio has 2 workflows. The first one is executed during pull request(PR) e.g. [named_entity_recognition_pr_dev_workflow.yml](../.github/workflows/named_entity_recognition_pr_dev_workflow.yml), and it helps to maintain code quality for all PRs. Usually, this pipeline uses a smaller dataset to make sure that the Prompt Flow job can be completed fast enough. 
+The template comes with a few Github workflows related to Prompt Flow flows that provide a jumpstart (named_entity_recognition, web_classification and math_coding). Each scenerio has 2 workflows. The first one is executed during pull request(PR) e.g. [named_entity_recognition_pr_dev_workflow.yml](../.github/workflows/named_entity_recognition_pr_dev_workflow.yml), and it helps to maintain code quality for all PRs. Usually, this pipeline uses a smaller dataset to make sure that the Prompt Flow job can be completed fast enough.
 
 The second Github workflow [named_entity_recognition_ci_dev_workflow.yml](../.github/workflows/named_entity_recognition_ci_dev_workflow.yml) is executed automatically before a PR is merged into the *development* or *main* branch. The main idea of this pipeline is to execute bulk run, evaluation on the full dataset for all prompt variants. Both the workflow can be modified and extended based on the project's requirements. 
 
@@ -116,9 +116,9 @@ Prompt Flow Connections helps securely store and manage secret keys or other sen
 
 This repository has 3 examples, and all the examples uses connection named `aoai` inside, we need to set up a connection with this name if we haven’t created it before. 
 
-This repository has all the examples using Azure OpenAI model `gpt-35-turbo`` deployed with the same name `gpt-35-turbo`, we need to set up this deployment if we haven’t created it before. 
+This repository has all the examples using Azure OpenAI model `gpt-35-turbo` deployed with the same name `gpt-35-turbo`. We need to set up this deployment if we haven’t created it before.
 
-Please go to Azure Machine Learning workspace portal, click `Prompt flow` -> `Connections` -> `Create` -> `Azure OpenAI`, then follow the instruction to create your own connections called `aoai`. Learn more on [connections](https://learn.microsoft.com/en-us/azure/machine-learning/prompt-flow/concept-connections?view=azureml-api-2). The samples uses a connection named "aoai" connecting to a gpt-35-turbo model deployed with the same name in Azure OpenAI. This connection should be created before executing the out-of-box flows provided with the template.
+Please go to Azure Machine Learning workspace portal, click `Prompt flow` -> `Connections` -> `Create` -> `Azure OpenAI`, then follow the instruction to create your own connections called `aoai`. Learn more on [connections](https://learn.microsoft.com/en-us/azure/machine-learning/prompt-flow/concept-connections?view=azureml-api-2). The samples uses a connection named `aoai` connecting to a gpt-35-turbo model deployed with the same name in Azure OpenAI. This connection should be created before executing the out-of-box flows provided with the template.
 
 ![aoai connection in Prompt Flow](images/connection.png)
 
@@ -158,7 +158,7 @@ Modify the configuration values in config.json file available for each example b
 - `KEYVAULT_NAME`:  This points to an Azure Key Vault, a service for securely storing and managing secrets, keys, and certificates.
 - `RESOURCE_GROUP_NAME`:  Name of the Azure resource group related to Azure ML workspace.
 - `WORKSPACE_NAME`:  This is name of Azure ML workspace.
-- `STANDARD_FLOW_PATH`:  This is relative folder path to files related to a standard flow. e.g.  e.g. "flows/standard_flow.yml"
+- `STANDARD_FLOW_PATH`:  This is relative folder path to files related to a standard flow. e.g. "flows/standard"
 - `EVALUATION_FLOW_PATH`:  This is an string value referring to evaluation flow paths. It can have multiple comma seperated values- one for each evaluation flow. e.g. "flows/eval_flow_1.yml,flows/eval_flow_2.yml"
 
 ### Update deployment_config.json in config folder
@@ -170,12 +170,10 @@ Modify the configuration values in deployment_config.json file for each environm
 - `ENDPOINT_NAME`: The value represents the name or identifier of the deployed endpoint for the prompt flow.
 - `ENDPOINT_DESC`: It provides a description of the endpoint. It describes the purpose of the endpoint, which is to serve a prompt flow online.
 - `DEPLOYMENT_DESC`: It provides a description of the deployment itself.
-- `DEPLOYMENT_NAME`: The value represents the name or identifier of the deployment. 
 - `PRIOR_DEPLOYMENT_NAME`: The name of prior deployment. Used during A/B deployment. The value is "" if there is only a single deployment. Refer to CURRENT_DEPLOYMENT_NAME property for the first deployment. 
 - `PRIOR_DEPLOYMENT_TRAFFIC_ALLOCATION`:  The traffic allocation of prior deployment. Used during A/B deployment. The value is "" if there is only a single deployment. Refer to CURRENT_DEPLOYMENT_TRAFFIC_ALLOCATION property for the first deployment. 
 - `CURRENT_DEPLOYMENT_NAME`: The name of current deployment.
-- `CURRENT_DEPLOYMENT_TRAFFIC_ALLOCATION`: The traffic allocation of current deployment.
-- `DEPLOYMENT_TRAFFIC_ALLOCATION`: This parameter represents the percentage allocation of traffic to this deployment. A value of 100 indicates that all traffic is directed to this deployment.
+- `CURRENT_DEPLOYMENT_TRAFFIC_ALLOCATION`: The traffic allocation of current deployment. A value of 100 indicates that all traffic is directed to this deployment.
 - `DEPLOYMENT_VM_SIZE`: This parameter specifies the size or configuration of the virtual machine instances used for the deployment.
 - `DEPLOYMENT_BASE_IMAGE_NAME`: This parameter represents the name of the base image used for creating the Prompt Flow runtime.
 -  `DEPLOYMENT_CONDA_PATH`: This parameter specifies the path to a Conda environment configuration file (usually named conda.yml), which is used to set up the deployment environment.


### PR DESCRIPTION
This are my notes from running through the `github_workflows_how_to_setup.md` doc. The PR changes are mostly nits of the `README` and GitHub workflow doc. Feel free to take them or leave them as you see fit.

I was able to run through the `github_workflows_how_to_setup.md` doc from end-to-end without much trouble when using the `azure_managed_endpoint` and running only the `named_entity_recognition` use case. I did not try out the other use cases like `math_coding` and `web_classification`. However, I did have some issues around deploying with the `kubernetes_endpoint`. Below I have listed some things that were unclear to me and more details about the Kubernetes issues that I hit.

Things that were unclear to me:

1. In `docs/github_workflows_how_to_setup.md`, it calls out that we need to provide a Key Vault name but doesn't mention if the user needs to create this. I believe this gets created automatically when creating a ML workspace, but maybe that should be called out there .
2. In `docs/github_workflows_how_to_setup.md` under  the `Update config.json` heading, the `EVALUATION_FLOW_PATH` definition is not clear on what needs to be here. The provided sample shows a directory path of `flows/evaluation` but the definition says to provide a list of file paths.
3. Initially, I made the mistake of opening a pull request to the microsoft GitHub repo instead of my forked repo. Calling out that you should do the PR to your own forked repo would be nice. This was just an oversight on my part, but also makes me wonder if there is any risk of allowing PRs to run from a forked repo? Will anyone potentially be able to deploy resources knowing that the secrets are set up with a service principal in the GithHub action secrets? 
4. In `docs/github_workflows_how_to_setup.md` under the heading `Update deployment_config.json in config folder`, it calls out that we need to provide a `DEPLOYMENT_VM_SIZE`. The default for `azure_managed_endpoint` in `deployment_config.json` looks good, but the `kubernetes_endpoint` provides `"DEPLOYMENT_VM_SIZE": "promptinstancetype"` as the value. Is this the intended default?
5. In `data_config.json` only one dataset contains the `RELATED_EXP_DATASET` field. It wasn't clear to me why this was provided in one dataset but not the others
6. In `docs/github_workflows_how_to_setup.md`, it states:  `Add your data into data folder under use case folder. It supports jsonl files and the examples already contains data files for both running and evaluating Prompt Flows. Refer to data_` -- I wasn't sure what the `Refer to data_` was supposed to be. This may just be a typo?

Kubernetes deployment issues:

1. There seems to be some missing steps on how to deploy via k8s. Do we need to run a workflow dispatch and provide an input of `True` for k8s? I tried this out using the workflow dispatch but received an error and a failed workflow. I'm not entirely sure what the issue is and I may just be doing something wrong. But briefly looking, it appears the `llmops/common/deployment/kubernetes_deployment.py` file does not handle an `--output-file` flag, but we provide it in the action and expect a `endpoint_principal.txt` file in the following `Read system managed id information` step. I have provided a screenshot of the error below.
2.  If the only way to provide a k8s deployment is through workflow dispatch, then the PR flow for running CI jobs seem to break down. Do I have to go in a manually start a workflow? Or is there another way to provide the Kubernetes experience without doing this?
![Screenshot 2023-11-09 at 12 39 10 PM](https://github.com/microsoft/llmops-promptflow-template/assets/88395136/409d42ed-75b6-4cfb-ac28-b3d236b94630)



