### PR TITLE
Add Publish Flow Feature

### DIFF
--- a/.azure-pipelines/platform_ci_dev_pipeline.yml
+++ b/.azure-pipelines/platform_ci_dev_pipeline.yml
@@ -154,7 +154,22 @@ stages:
               replace@youremail.com
             instructions: "$(run_id_from_submit_job)"
             onTimeout: 'reject'
-      
+        #=====================================
+        # Publish the flow in promptflow blade
+        #===================================== 
+      - job: publish_flow
+        dependsOn: 
+        - ApproveDeployment
+        steps:
+        - template: templates/get_connection_details.yml
+        - template: templates/configure_azureml_agent.yml
+        - template: templates/publish_prompt_flow.yml
+          parameters:
+              SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+              flow_to_execute: ${{ parameters.flow_to_execute }}
+              DEPLOY_ENVIRONMENT: ${{ parameters.exec_environment }}
+              BUILD_ID: $(Build.Buildid)
+
       - job: deploy_flow
         dependsOn: 
         - ApproveDeployment
@@ -195,7 +210,7 @@ stages:
               readarray arr <"model_version.txt"
               model_version=${arr[0]}
               echo $model_version
-              echo "##vso[task.setvariable variable=MODEL_VERSION;isOutput=true;]$model_version" 
+              echo "##vso[task.setvariable variable=MODEL_VERSION;isOutput=true;]$model_version"
 
         #=====================================
         # Executes Kubernetes deployment when parameter deployment_type == 'aks'

--- a/.azure-pipelines/templates/publish_prompt_flow.yml
+++ b/.azure-pipelines/templates/publish_prompt_flow.yml
@@ -1,0 +1,37 @@
+parameters:
+- name: SUBSCRIPTION_ID
+  type: string
+- name: flow_to_execute
+  type: string
+- name: DEPLOY_ENVIRONMENT
+  type: string
+- name: BUILD_ID
+  type: string
+
+steps:
+- task: AzureCLI@2
+  displayName: Publish Prompt Flow 
+  continueOnError: false
+  inputs: 
+    azureSubscription: $(AZURE_RM_SVC_CONNECTION)
+    scriptType: bash
+    workingDirectory: $(System.DefaultWorkingDirectory)
+    scriptLocation: inlineScript
+    inlineScript: |
+      config_path="./${{ parameters.flow_to_execute }}/llmops_config.json"
+      env_name=${{ parameters.DEPLOY_ENVIRONMENT }}
+      selected_object=$(jq ".envs[] | select(.ENV_NAME == \"$env_name\")" "$config_path")
+
+      if [[ -n "$selected_object" ]]; then
+        echo "$selected_object"
+        RESOURCE_GROUP_NAME=$(echo "$selected_object" | jq -r '.RESOURCE_GROUP_NAME')
+        WORKSPACE_NAME=$(echo "$selected_object" | jq -r '.WORKSPACE_NAME')
+        STANDARD_FLOW_PATH=$(echo "$selected_object" | jq -r '.STANDARD_FLOW_PATH')
+        FLOW_TYPE=$(echo "$selected_object" | jq -r '.FLOW_TYPE')
+        if [[ ! -n "$FLOW_TYPE" ]]; then
+          FLOW_TYPE=standard
+        fi
+      else
+        echo "Object in config file not found"
+      fi
+      pfazure flow create --flow ./${{ parameters.flow_to_execute }}/$STANDARD_FLOW_PATH --set display_name=${{ parameters.flow_to_execute }}:${{ parameters.BUILD_ID }} --set type=$FLOW_TYPE --subscription ${{ parameters.SUBSCRIPTION_ID }} --resource-group $RESOURCE_GROUP_NAME --workspace-name $WORKSPACE_NAME

--- a/docs/Azure_devops_how_to_setup.md
+++ b/docs/Azure_devops_how_to_setup.md
@@ -388,6 +388,7 @@ Modify the configuration values in `llmops_config.json` file available for each 
 - `KEYVAULT_NAME`:  This points to an Azure Key Vault, a service for securely storing and managing secrets, keys, and certificates.
 - `RESOURCE_GROUP_NAME`:  Name of the Azure resource group related to Azure ML workspace.
 - `WORKSPACE_NAME`:  This is name of Azure ML workspace.
+- `FLOW_TYPE`:  Flow type. Default to be “standard” if not specified. Available types are: “standard”, “chat”.
 - `STANDARD_FLOW_PATH`:  This is relative folder path to files related to a standard flow. e.g. "flows/standard"
 - `EVALUATION_FLOW_PATH`:  This is a string value referring to evaluation flow folders. It can have one or more comma separated values - one for each evaluation flow. e.g. "flows/eval_flow_1,flows/eval_flow_2"
 

--- a/docs/github_workflows_how_to_setup.md
+++ b/docs/github_workflows_how_to_setup.md
@@ -336,6 +336,7 @@ Modify the configuration values in the `llmops_config.json` file available for e
 - `KEYVAULT_NAME`:  This points to an Azure Key Vault related to the Azure ML service, a service for securely storing and managing secrets, keys, and certificates.
 - `RESOURCE_GROUP_NAME`:  Name of the Azure resource group related to Azure ML workspace.
 - `WORKSPACE_NAME`:  This is name of Azure ML workspace.
+- `FLOW_TYPE`:  Flow type. Default to be “standard” if not specified. Available types are: “standard”, “chat”.
 - `STANDARD_FLOW_PATH`:  This is the relative folder path to files related to a standard flow. e.g.  e.g. "flows/standard_flow.yml"
 - `EVALUATION_FLOW_PATH`:  This is a string value referring to relative evaluation flow paths. It can have multiple comma separated values- one for each evaluation flow. e.g. "flows/eval_flow_1.yml,flows/eval_flow_2.yml"
 

--- a/math_coding/llmops_config.json
+++ b/math_coding/llmops_config.json
@@ -6,6 +6,7 @@
                 "KEYVAULT_NAME": "",
                 "RESOURCE_GROUP_NAME": "",
                 "WORKSPACE_NAME": "",
+                "FLOW_TYPE": "chat",
                 "STANDARD_FLOW_PATH": "flows/math_standard_flow",
                 "EVALUATION_FLOW_PATH": "flows/math_evaluation_flow"
             },
@@ -15,6 +16,7 @@
                 "KEYVAULT_NAME": "",
                 "RESOURCE_GROUP_NAME": "",
                 "WORKSPACE_NAME": "",
+                "FLOW_TYPE": "chat",
                 "STANDARD_FLOW_PATH": "flows/math_standard_flow",
                 "EVALUATION_FLOW_PATH": "flows/math_evaluation_flow"
             }

--- a/named_entity_recognition/llmops_config.json
+++ b/named_entity_recognition/llmops_config.json
@@ -6,6 +6,7 @@
                 "KEYVAULT_NAME": "",
                 "RESOURCE_GROUP_NAME": "",
                 "WORKSPACE_NAME": "",
+                "FLOW_TYPE": "standard",
                 "STANDARD_FLOW_PATH": "flows/standard",
                 "EVALUATION_FLOW_PATH": "flows/evaluation"
             },
@@ -15,6 +16,7 @@
                 "KEYVAULT_NAME": "",
                 "RESOURCE_GROUP_NAME": "",
                 "WORKSPACE_NAME": "",
+                "FLOW_TYPE": "standard",
                 "STANDARD_FLOW_PATH": "flows/standard",
                 "EVALUATION_FLOW_PATH": "flows/evaluation"
             },
@@ -24,6 +26,7 @@
                 "KEYVAULT_NAME": "",
                 "RESOURCE_GROUP_NAME": "",
                 "WORKSPACE_NAME": "",
+                "FLOW_TYPE": "standard",
                 "STANDARD_FLOW_PATH": "flows/post-production-evaluation"
             }
     ]


### PR DESCRIPTION
This feature publishes the flow with the build ID tag on the prompt flow blade, designating the service principal as the owner, and provides developers with the ability to clone and test the flow on Azure without needing to prepare the local environment.