### PR TITLE
Add Publish Flow Feature (Revised)

### DIFF
--- a/.azure-pipelines/platform_ci_dev_pipeline.yml
+++ b/.azure-pipelines/platform_ci_dev_pipeline.yml
@@ -147,7 +147,7 @@ stages:
     # Manual Approval is enabled by default
     # For removal of Manual Approval:
     # Remove the job ApproveDeployment
-    # and remove its dependency from job deploy_flow
+    # and remove its dependency from job deploy_flow and publish_flow
     #=====================================
       jobs:
       - job: ApproveDeployment
@@ -165,7 +165,25 @@ stages:
               replace@youremail.com
             instructions: "$(run_id_from_submit_job)"
             onTimeout: 'reject'
-      
+
+      #=====================================
+      # Publish the flow in promptflow blade
+      #===================================== 
+      - job: publish_flow
+        dependsOn: 
+        - ApproveDeployment
+        steps:
+        - template: templates/get_connection_details.yml
+        - template: templates/configure_azureml_agent.yml
+        - template: templates/publish_promptflow.yml
+          parameters:
+              SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+              USE_CASE_BASE_PATH: ${{ parameters.use_case_base_path }}
+              DEPLOY_ENVIRONMENT: ${{ parameters.exec_environment }}
+              BUILD_ID: $(Build.Buildid)
+              WORKSPACE_NAME: ${{ parameters.WORKSPACE_NAME }}
+              RESOURCE_GROUP_NAME: ${{ parameters.RESOURCE_GROUP_NAME }}
+
       - job: deploy_flow
         dependsOn: 
         - ApproveDeployment

--- a/.azure-pipelines/templates/publish_promptflow.yml
+++ b/.azure-pipelines/templates/publish_promptflow.yml
@@ -1,0 +1,30 @@
+parameters:
+- name: SUBSCRIPTION_ID
+  type: string
+- name: USE_CASE_BASE_PATH
+  type: string
+- name: DEPLOY_ENVIRONMENT
+  type: string
+- name: BUILD_ID
+  type: string
+- name: WORKSPACE_NAME
+  type: string
+- name: RESOURCE_GROUP_NAME
+  type: string
+
+steps:
+- task: AzureCLI@2
+  displayName: Publish Prompt Flow 
+  continueOnError: false
+  inputs: 
+    azureSubscription: $(AZURE_RM_SVC_CONNECTION)
+    scriptType: bash
+    workingDirectory: $(System.DefaultWorkingDirectory)
+    scriptLocation: inlineScript
+    inlineScript: |
+      config_path="./${{ parameters.USE_CASE_BASE_PATH }}/experiment.yaml"
+      STANDARD_FLOW_NAME="${"$(cat $config_path | yq .flow)"/"flows\/"/""}"
+      STANDARD_FLOW_PATH="./${{ parameters.USE_CASE_BASE_PATH }}/$(cat $config_path | yq .flow)"
+
+      echo "Publishing standard flow..."
+      pfazure flow create --flow $STANDARD_FLOW_PATH --set display_name="${{ parameters.USE_CASE_BASE_PATH }}"_"$STANDARD_FLOW_NAME":${{ parameters.BUILD_ID }} --set type=chat --subscription ${{ parameters.SUBSCRIPTION_ID }} --resource-group ${{ parameters.RESOURCE_GROUP_NAME }} --workspace-name ${{ parameters.WORKSPACE_NAME }}


### PR DESCRIPTION
This feature publishes the flow with the build ID tag on the prompt flow blade, designating the service principal as the owner, and provides developers with the ability to clone and test the flow on Azure without needing to prepare the local environment.