### PR TITLE
'none' as additional option for deployment_type in CI pipelines

### DIFF
--- a/.azure-pipelines/platform_ci_dev_pipeline.yml
+++ b/.azure-pipelines/platform_ci_dev_pipeline.yml
@@ -5,7 +5,7 @@ parameters:
  - name: use_case_base_path
    displayName: "type of model to execute"
  - name: deployment_type
-   displayName: "determine type of deployment - aks, aml, docker, webapp"
+   displayName: "determine type of deployment - aks, aml, docker, webapp, none"
  - name: registry_details
    displayName: "determine the variable containing acr details"
  - name: RESOURCE_GROUP_NAME

--- a/.github/workflows/platform_ci_dev_workflow.yml
+++ b/.github/workflows/platform_ci_dev_workflow.yml
@@ -15,7 +15,7 @@ on:
         default: "web_classification"
       deployment_type:
         type: string
-        description: "Determine type of deployment - aml, aks, docker, webapp"
+        description: "Determine type of deployment - aml, aks, docker, webapp, none"
         required: true
     secrets:
       azure_credentials:
@@ -165,6 +165,7 @@ jobs:
   # Execute platform_cd_dev_workflow flow for deployment of flows
   #=====================================
   deploy-flow:
+    if: ${{ inputs.deployment_type != 'none' }}
     uses: ./.github/workflows/platform_cd_dev_workflow.yml
     needs: flow-experiment-and_evaluation
     with:

--- a/.jenkins/pipelines/platform_ci_dev
+++ b/.jenkins/pipelines/platform_ci_dev
@@ -11,7 +11,7 @@ pipeline {
     parameters {
         string(name: 'use_case_base_path', defaultValue: 'named_entity_recognition', description: 'The flow use-case to execute')
         string(name: 'env_name', defaultValue: 'dev', description: 'Execution Environment')
-        string(name: 'deployment_type', defaultValue: 'webapp', description: 'Determine type of deployment - aml, aks, webapp')
+        string(name: 'deployment_type', defaultValue: 'webapp', description: 'Determine type of deployment - aml, aks, webapp, none')
         string(name: 'rg_name', description: 'Azure Resource Group Name')
         string(name: 'ws_name', description: 'AzureML Workspace Name')
         string(name: 'kv_name', description: 'Azure Key Vault Name')
@@ -173,6 +173,9 @@ load_dotenv('.env')
 
         // Execute Platform CD Pipeline to deploy flow to specified deployment type
         stage('Execute Platform CD Pipeline to deploy flow') {
+            when {
+                expression { params.deployment_type != 'none' }
+            }
             steps {
                 script {
                     build job: 'platform_cd_dev', parameters: [


### PR DESCRIPTION
Added `"none"` option for `deployment_type` in platform CI pipeline, including the three versions: ADO (no change needed), Github and Jenkins. If option is set to "none", then deployment is skipped.

Tested with "none" option here: https://github.com/mariamedp/llmops-promptflow-template/actions/runs/10060336244/workflow

Closes #189
