### PR TITLE
Fix Typo: Set Correct Environment Variable for Logging Level (PF_LOGGING_LEVEL)

### DIFF
--- a/llmops/common/deployment/kubernetes_deployment.py
+++ b/llmops/common/deployment/kubernetes_deployment.py
@@ -182,7 +182,7 @@ def create_kubernetes_deployment(
                     environment_variables[key] = value
                 environment_variables["PROMPTFLOW_RUN_MODE"] = "serving"
                 environment_variables["PROMPTFLOW_SERVING_ENGINE"] = "fastapi"
-                environment_variables["F_LOGGING_LEVEL"] = "WARNING"
+                environment_variables["PF_LOGGING_LEVEL"] = "WARNING"
                 environment_variables["PRT_CONFIG_OVERRIDE"] = (
                     f"deployment.subscription_id={config.subscription_id},"
                     f"deployment.resource_group={config.resource_group_name},"


### PR DESCRIPTION
This pull request fixes a typo in the environment variable name for controlling the logging level.

Changed F_LOGGING_LEVEL to PF_LOGGING_LEVEL to ensure the correct environment variable is set for Prompt Flow logging.
This change aligns with the expected configuration and prevents potential misconfiguration of logging levels during Prompt Flow execution.
